### PR TITLE
Always something new to learn

### DIFF
--- a/reverse_each_word.rb
+++ b/reverse_each_word.rb
@@ -1,0 +1,38 @@
+def sent
+"The rain in Spain stays mainly on the plane."
+end
+
+def sent2
+"By the blood of our fathers, by the blood of our sons."
+end
+
+ def reverse_each_word(string)
+ rirrom = []
+ string.split(" ").each do |y|
+   rirrom << y.reverse!
+
+  end
+  rirrom.join(" ")
+end
+
+def reverse_each_word1(string2)
+  words = string2.split(" ")
+  reversed_words = words.collect do |x|
+    x.reverse
+  end
+  reversed_words.join(" ")
+end
+
+
+#### This code also works ####
+def reverse_each_word_1(str)
+  words = str.split(" ")
+  reversed_words = words.map { |x| x.reverse }
+ reversed_words.join(" ")
+end
+
+def reverse_each_word_3(string2)
+  string2.split(" ").collect do |x|
+    x.reverse 
+  end.join(" ")
+end

--- a/spec/reverse_each_word_spec.rb
+++ b/spec/reverse_each_word_spec.rb
@@ -10,6 +10,6 @@ end
 describe '#reverse_each_word' do
   let(:sentence2) { "Hi again, just making sure it's reversed!" }
   it 'reverses all the words in a string without reversing the order of the words' do
-    expect(reverse_each_word(sentence2)).to eq("iH niaga, tsuj gnikam erus s'ti !desrever")
+    expect(reverse_each_word(sentence2)).to eq("iH ,niaga tsuj gnikam erus s'ti !desrever")
   end
 end


### PR DESCRIPTION
This lab was meant to teach one the difference between `.each` and `.collect`. From what I understand using the `.each` method will always return the original, unaltered array for example:
```
def some_method(some_array = [1,2,3,4,5])
  some_array.each do |x|
    x + "!" 
  end # Here the array is [1!, 2!, 3!, 4!, 5!]
end **#But when it reaches here it's [1,2,3,4,5]**
```
`.collect` or `.map`(same thing) will do almost the same thing but instead the output will return the altered array:
```
def some_method(some_array = [1,2,3,4,5])
  some_array.collect do |x|
    x + "!" 
  end # Here the array is [1!, 2!, 3!, 4!, 5!]
end **#And it outputs [1!, 2!, 3!, 4!, 5!]**
```
I also discovered that the following two examples are equal to each other:
```
array.collect/each do |x|
  x + 1
end
```
AND
```
array.collect/each {|x| x + 1}
```
The first bracket "{" is a `do` keyword and the closing bracket "}" is an `end` keyword.

Lastly, I was informed that an `end` keywords can have a method attached to it. Like so: `end.join(" ")`
take a look at the last method, `reverse_each_word_3` in the attached code and there is an example of this. What I think is that if you add a method to the `end` keyword of a block of code you are operating on the code as it is when it hits that `end`. That seems to make the most sense. It's also worth taking note of this method:
```
def reverse_each_word1(string2)
  words = string2.split(" ")
  reversed_words = words.collect do |x|
    x.reverse
  end
  reversed_words.join(" ")
end
```
This method shows that you can take a `.each` or `.collect` method and set it equal to a variable. Shown here where `reversed_words = words.collect do |x|` I'm sure this will provide useful in the future.

Finally, finally I was trying to make this code work: 
```
def reverse_each_word(string2)
  string2.split(" ").collect do |x|
   x.reverse.join(" ")
 end
end
```
`x.reverse.join(" ")` was producing an error and now I know why. The `collect do |x|` is operating on each letter in the `string2` array because of the `x.reverse` remember the words are not reversed **just the letters in the words** trying to `.join` will not work because you are trying to join the reversed letters, but to what? It seems like it would make sense, but those words are not back in an array to be operated on with `.join`, yet when you want to `end.join` that works because you're operating on the array, manipulated by the `.collect` block. This was more a lesson in understanding operations better and what values are present in the code at every `end`.
